### PR TITLE
Increase the number of threads for fastqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that users understand how the changes affect the new version.
 
 version develop
 ---------------------------
++ Increase the number of fastqc threads. This prevents java heapspace memory
+  errors.
 + Make running isoseq3 refine optional. This changes the default behaviour
   to not running isoseq3 refine.
 + Add FastQC to the pipeline.

--- a/PacBio-subreads-processing.wdl
+++ b/PacBio-subreads-processing.wdl
@@ -85,6 +85,7 @@ workflow SubreadsProcessing {
                         seqFile = executeRefine.outputFLNCfile,
                         outdirPath = outputDirectory + "/" + subreads.subreads_id + "/" + basename(executeRefine.outputFLNCfile, ".bam") + "-fastqc",
                         format = "bam",
+                        threads = 4,
                         dockerImage = dockerImages["fastqc"]
                 }
             }
@@ -95,6 +96,7 @@ workflow SubreadsProcessing {
                         seqFile = bamFile,
                         outdirPath = outputDirectory + "/" + subreads.subreads_id + "/" + basename(bamFile, ".bam") + "-fastqc",
                         format = "bam",
+                        threads = 4,
                         dockerImage = dockerImages["fastqc"]
                 }
             }


### PR DESCRIPTION
This is the easiest way to increase the amount of memory that is
assigned to the java process, since the fastqc wrapper assigns
250MB*threads.

This fixes issue #5 

### Checklist
- [x] Pull request details were added to CHANGELOG.md.
