### PR TITLE
Add sample names to workflow output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that users understand how the changes affect the new version.
 
 version develop
 ---------------------------
++ Add sample names to workflow output as `outputSamples`.
 + Rename fastqc tasks to correctly reflect what input they process.
 + Rename test files to show PacBio file structure more clearly.
 + Increase the number of fastqc threads. This prevents java heapspace memory

--- a/PacBio-subreads-processing.wdl
+++ b/PacBio-subreads-processing.wdl
@@ -106,7 +106,7 @@ workflow SubreadsProcessing {
 
             # Determine the sample name from the bam file name. This is needed
             # because the sample names are determine from the headers in the
-            # fasta file, which is not accessible from the WDL
+            # fasta file, which is not accessible from the WDL.
             String sampleName = sub(sub(bamFile, ".*--", ""),".bam", "")
 
         }

--- a/PacBio-subreads-processing.wdl
+++ b/PacBio-subreads-processing.wdl
@@ -167,5 +167,6 @@ workflow SubreadsProcessing {
         outputRefineStderr: {description: "Refine STDERR log file(s)."}
         outputHtmlReport: {description: "FastQC output HTML file(s)."}
         outputZipReport: {description: "FastQC output support file(s)."}
+        outputSamples: {description: "The name(s) of the sample(s)."}
     }
 }

--- a/PacBio-subreads-processing.wdl
+++ b/PacBio-subreads-processing.wdl
@@ -108,7 +108,6 @@ workflow SubreadsProcessing {
             # because the sample names are determine from the headers in the
             # fasta file, which is not accessible from the WDL.
             String sampleName = sub(sub(bamFile, ".*--", ""),".bam", "")
-
         }
     }
 

--- a/PacBio-subreads-processing.wdl
+++ b/PacBio-subreads-processing.wdl
@@ -104,6 +104,11 @@ workflow SubreadsProcessing {
             File fastqcHtmlReport = select_first([executeFastqcRefine.htmlReport, executeFastqcLima.htmlReport])
             File fastqcZipReport = select_first([executeFastqcRefine.reportZip, executeFastqcLima.reportZip])
 
+            # Determine the sample name from the bam file name. This is needed
+            # because the sample names are determine from the headers in the
+            # fasta file, which is not accessible from the WDL
+            String sampleName = sub(sub(bamFile, ".*--", ""),".bam", "")
+
         }
     }
 
@@ -128,6 +133,7 @@ workflow SubreadsProcessing {
         Array[File?] outputRefineSummary = flatten(executeRefine.outputFilterSummaryFile)
         Array[File?] outputRefineReport = flatten(executeRefine.outputReportFile)
         Array[File?] outputRefineStderr = flatten(executeRefine.outputSTDERRfile)
+        Array[String] outputSamples = flatten(sampleName)
     }
 
     parameter_meta {

--- a/tests/test.pipelines.yml
+++ b/tests/test.pipelines.yml
@@ -4,6 +4,9 @@
   command: >-
     cromwell run -o tests/cromwell.options.json
     -i tests/integration/dna.json PacBio-subreads-processing.wdl
+  stdout:
+    contains_regex:
+      - 'SubreadsProcessing.outputSamples.*"Sample_1_3p"'
   files:
     - path: test-output/batch_1_march/batch_1_march.ccs.bam
     - path: test-output/batch_1_march/batch_1_march.ccs.bam.pbi
@@ -139,6 +142,9 @@
   command: >-
     cromwell run -o tests/cromwell.options.json
     -i tests/integration/rna.json PacBio-subreads-processing.wdl
+  stdout:
+    contains_regex:
+      - 'SubreadsProcessing.outputSamples.*"Sample_1_3p"'
   files:
     - path: test-output/batch_1_march/batch_1_march.ccs.bam
     - path: test-output/batch_1_march/batch_1_march.ccs.bam.pbi


### PR DESCRIPTION
The sample names are determined by the content of the barcodes fasta
file, which is not accessible for the workflow. This change extracts the
sample names from the lima output files, and adds them to the output as
an array of strings. This way, workflows that incorporate
PacBio-subreads-processing can access the sample names directly

### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [x] Documentation was updated (if required).
- [x] Workflow `parameter_meta` was added/updated (if required).
